### PR TITLE
Update install_with_vagrant.rst

### DIFF
--- a/en/developer_guide/install_with_vagrant.rst
+++ b/en/developer_guide/install_with_vagrant.rst
@@ -71,7 +71,7 @@ Clone the provisioning repository in another folder :
 
 .. code-block:: bash
 
-    $ git clone git@github.com:open-orchestra/open-orchestra-provision.git
+    $ git clone https://github.com/open-orchestra/open-orchestra-provision.git
 
 Install roles from ansible-galaxy
 ---------------------------------


### PR DESCRIPTION
Install with https for better compatibility instead of git ssh key
